### PR TITLE
Make scrolling more convenient

### DIFF
--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -46,7 +46,7 @@ export default function Home() {
 
 	return (
 		<div className="bg-background w-screen h-screen">
-			<div className="w-[75vw] h-[90vh] m-auto overflow-y-scroll hide-scrollbar">
+			<div className="w-[100vw] h-[90vh] px-[12.5vw] m-auto overflow-y-scroll hide-scrollbar">
 				{history.map((row, i) => {
 					return (
 						<div key={i}>


### PR DESCRIPTION
Makes the text output scrollable even if you scroll in the free space on left or right side of text.

Basically, if you try scrolling the in red box area shown in the image below, the text should also scroll now.


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ef172233-681c-4133-b5aa-ec2efcbd0860" />


Previously, the text output occupied 75% width, this automatically created 12.5% margin width on both sides of the text.
That is, the red boxes were actually a giant margin for the text.
Since margin is actually exterior of the text box [as per box model](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Box_model#parts_of_a_box), scrolling in the red boxes does not scroll the text.

Padding is part of the interior of the box, so I have changed the text to occupy 100% width with 12.5% padding on both sides.

Now, the red boxes are the padding, which is part of the text box, so scrolling in it makes the text scroll.

